### PR TITLE
Fix bug when results are not binary

### DIFF
--- a/src/eel.erl
+++ b/src/eel.erl
@@ -9,6 +9,7 @@
 -export([
     compile/1,
     compile_file/1,
+    compile_file/2,
     render/3,
     render/4
 ]).
@@ -28,6 +29,11 @@ compile(Bin) ->
     Flattened = flatten(Dynamic),
     AST = parse(Flattened),
     {Static, AST}.
+
+compile_file(App, FileName0) ->
+    PrivDir = code:priv_dir(App),
+    FileName = filename:join([PrivDir, "templates", FileName0]),
+    compile_file(FileName).
 
 compile_file(FileName) ->
     case file:read_file(FileName) of

--- a/src/eel_utils.erl
+++ b/src/eel_utils.erl
@@ -1,0 +1,31 @@
+-module(eel_utils).
+
+-export([to_binary/1, to_binary/2]).
+
+-dialyzer({nowarn_function, to_binary/2}).
+
+to_binary(Value) ->
+    to_binary(Value, undefined).
+
+to_binary(Bin, _) when is_binary(Bin) ->
+    Bin;
+to_binary(undefined, _) ->
+    <<>>;
+to_binary(Atom, undefined) when is_atom(Atom) ->
+    erlang:atom_to_binary(Atom);
+to_binary(Atom, Encoding) when is_atom(Atom), is_atom(Encoding) ->
+    erlang:atom_to_binary(Atom, Encoding);
+to_binary(Float, undefined) when is_float(Float) ->
+    erlang:float_to_binary(Float);
+to_binary(Float, Options) when is_float(Float), is_list(Options) ->
+    erlang:float_to_binary(Float, Options);
+to_binary(Int, undefined) when is_integer(Int) ->
+    erlang:integer_to_binary(Int);
+to_binary(Int, Base) when is_integer(Int), is_integer(Base) ->
+    erlang:integer_to_binary(Int, Base);
+to_binary(List, undefined) when is_list(List) ->
+    erlang:iolist_to_binary(List);
+to_binary(Tuple, undefined) when is_tuple(Tuple) ->
+    to_binary(erlang:tuple_to_list(Tuple));
+to_binary(_, _) ->
+    <<>>.


### PR DESCRIPTION
e.g when an integer is in the `iolist_to_binary` args array, the result is a binary with decimals and not a string.