### PR TITLE
refactor: change comment marker to %

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ The Erlang code it's written between section punctuations. These section punctua
 - `.%>` indicates that the expression ends;
 - `%>` indicates that the expression continues;
 - `<%` continues the last expression if it ends with `%>`;
-- `<%#` starts a comment;
-- `#%>` ends a comment.
+- `<%%` starts a comment;
+- `%%>` ends a comment.
 
 The bindings are the unbound/required variables of the template. The syntax it's a map with keys as atoms starting with upper case, e.g:
 

--- a/src/eel_compile.erl
+++ b/src/eel_compile.erl
@@ -144,7 +144,7 @@ tokenize_expr(<<"<%", T0/binary>>) ->
     {StartMarker, T} = retrieve_marker(T0, <<>>),
     tokenize_by_marker(StartMarker, T).
 
-tokenize_by_marker(<<"#">>, Bin) ->
+tokenize_by_marker(<<"%">>, Bin) ->
     comment(Bin, <<>>);
 tokenize_by_marker(StartMarker, Bin) ->
     case expression(Bin, StartMarker, <<>>) of
@@ -155,10 +155,10 @@ tokenize_by_marker(StartMarker, Bin) ->
             {error, Reason}
     end.
 
-comment(<<32, "#%>", T/binary>>, Cache) ->
+comment(<<32, "%%>", T/binary>>, Cache) ->
     Comment = trim(Cache),
     {ok, {Comment, T}};
-comment(<<"#%>", _/binary>>, _Cache) ->
+comment(<<"%%>", _/binary>>, _Cache) ->
     % TODO: Handle missing_space
     {error, missing_space};
 comment(<<H, T/binary>>, Cache) ->

--- a/src/eel_render.erl
+++ b/src/eel_render.erl
@@ -136,8 +136,8 @@ compiled_test() ->
     Bin = <<
         "<h1>"
         "<%= fun() -> %>"
-        "<%# Local funs are only accepted with arity 0 or 1."
-        "    If arity 1, it will receives bindings as args. #%>"
+        "<%% Local funs are only accepted with arity 0 or 1."
+        "    If arity 1, it will receives bindings as args. %%>"
         "<% fun(#{'Title' := Title}) -> eel_render:echo(Title) end %>"
         "<% end .%>"
         "</h1>"


### PR DESCRIPTION
This makes more sense since the `%` is the Erlang marker for comments.