### PR TITLE
Eval to iolist() instead of binary()

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Much like Elixir has EEx, Erlang has EEl, or Embedded Erlang. With EEl we can em
 A binary or a file can be evaluated to a binary, e.g.:
 
 ```erlang
-1> eel:eval(<<"Hello, <%= Who .%>!">>, #{'Who' => <<"World">>}).
-<<"Hello, World!">>
+1> eel:eval(<<"Hello, <%= Name .%>!">>, #{'Name' => <<"World">>}).
+[<<"Hello, ">>,<<"World">>,<<"!">>]
 ```
 
 ### Module
@@ -18,10 +18,10 @@ A binary or a file can be evaluated to a binary, e.g.:
 A binary or a file can be compiled to a module, e.g.:
 
 ```erlang
-1> eel:compile_to_module(<<"Hello, <%= Who .%>!">>, foo).
+1> eel:compile_to_module(<<"Hello, <%= Name .%>!">>, foo).
 {ok,foo}
-2> foo:eval(#{'Who' => <<"World">>}).
-<<"Hello, World!">>
+2> foo:eval(#{'Name' => <<"World">>}).
+[<<"Hello, ">>,<<"World">>,<<"!">>]
 ```
 
 ## Example
@@ -40,7 +40,7 @@ render(Bindings) ->
             "<title><%= Title .%></title>"
         "</head>"
         "<body>"
-            "Hello, <%= Who .%>!"
+            "Hello, <%= Name .%>!"
         "</body>"
         "</html>"
     >>),
@@ -61,7 +61,9 @@ and type this in the Erlang shell
 
 ```erlang
 1> {_, Snapshot} = foo:render(#{title => <<"Hey!">>, who => <<"World">>}).
-{<<"<html><head><title>Hey!</title></head><body>Hello, World!</body></html>">>,
+{[<<"<html><head><title>">>,<<"Hey!">>,
+  <<"</title></head><body>Hello, ">>,<<"World">>,
+  <<"!</body></html>">>],
  #{ast =>
        [{2,
          {{1,20},
@@ -73,7 +75,8 @@ and type this in the Erlang shell
          {{1,61},
           [{call,1,
                {remote,1,{atom,1,eel_converter},{atom,1,to_binary}},
-               [{'fun',1,{clauses,[{clause,1,[],[],[{var,1,...}]}]}}]}]}}],
+               [{'fun',1,
+                    {clauses,[{clause,1,[],[],[{var,1,...}]}]}}]}]}}],
    bindings => #{'Title' => <<"Hey!">>,'Who' => <<"World">>},
    changes => [{2,<<"Hey!">>},{4,<<"World">>}],
    dynamic =>
@@ -84,7 +87,9 @@ and type this in the Erlang shell
         {5,{{1,72},<<"!</body></html>">>}}],
    vars => [{2,['Title']},{4,['Who']}]}}
 2> {Bin, _} = foo:render(#{who => <<"Erlang">>}, Snapshot).
-{<<"<html><head><title>Hey!</title></head><body>Hello, Erlang!</body></html>">>,
+{[<<"<html><head><title>">>,<<"Hey!">>,
+  <<"</title></head><body>Hello, ">>,<<"Erlang">>,
+  <<"!</body></html>">>],
  #{ast =>
        [{2,
          {{1,20},
@@ -96,7 +101,8 @@ and type this in the Erlang shell
          {{1,61},
           [{call,1,
                {remote,1,{atom,1,eel_converter},{atom,1,to_binary}},
-               [{'fun',1,{clauses,[{clause,1,[],[],[{var,1,...}]}]}}]}]}}],
+               [{'fun',1,
+                    {clauses,[{clause,1,[],[],[{var,1,...}]}]}}]}]}}],
    bindings => #{'Title' => <<"Hey!">>,'Who' => <<"Erlang">>},
    changes => [{4,<<"Erlang">>}],
    dynamic =>
@@ -110,7 +116,9 @@ and type this in the Erlang shell
 
 Looking at the pattern matched results, the first tuple element contains the evaluated value
 ```erlang
-<<"<html><head><title>Hey!</title></head><body>Hello, World!</body></html>">>
+[<<"<html><head><title>">>,<<"Hey!">>,
+ <<"</title></head><body>Hello, ">>,<<"World">>,
+ <<"!</body></html>">>]
 ```
 and the second a metadata called `snapshot` (see next)
 ```erlang
@@ -125,7 +133,8 @@ and the second a metadata called `snapshot` (see next)
          {{1,61},
           [{call,1,
                {remote,1,{atom,1,eel_converter},{atom,1,to_binary}},
-               [{'fun',1,{clauses,[{clause,1,[],[],[{var,1,...}]}]}}]}]}}],
+               [{'fun',1,
+                    {clauses,[{clause,1,[],[],[{var,1,...}]}]}}]}]}}],
    bindings => #{'Title' => <<"Hey!">>,'Who' => <<"World">>},
    changes => [{2,<<"Hey!">>},{4,<<"World">>}],
    dynamic =>

--- a/src/eel_engine.erl
+++ b/src/eel_engine.erl
@@ -13,13 +13,13 @@
 -type index()         :: pos_integer().
 -type line()          :: pos_integer().
 -type column()        :: pos_integer().
+-type position()      :: {line(), column()}.
 -type expression()    :: binary().
 -type state()         :: term().
--type token()         :: term().
--type static()        :: [binary()].
+-type token()         :: {index(), {position(), expression()}}.
+-type static()        :: [token()].
 -type dynamic()       :: [token()].
 -type ast()           :: erl_syntax:syntaxTree().
--type position()      :: {line(), column()}.
 -type marker_id()     :: atom().
 -type marker_symbol() :: nonempty_string().
 -type marker()        :: {marker_id(), { Start :: marker_symbol()
@@ -67,6 +67,6 @@
 -callback handle_body( state() ) -> {ok, {static(), dynamic()}} | {error, term()}.
 
 %% compile
--callback handle_compile(token(), state()) -> {ok, state()} | {error, term()}.
+-callback handle_compile([token()], state()) -> {ok, state()} | {error, term()}.
 
 -callback handle_ast( state() ) -> {ok, ast()} | {error, term()}.

--- a/src/eel_evaluator.erl
+++ b/src/eel_evaluator.erl
@@ -15,7 +15,7 @@
 
 % Types
 -type snapshot() :: eel_renderer:snapshot().
--type tokens()   :: eel_tokenizer:tokens().
+-type token()    :: eel_tokenizer:token().
 -type static()   :: eel_engine:static().
 -type dynamic()  :: eel_engine:dynamic().
 
@@ -29,7 +29,7 @@
 %% -----------------------------------------------------------------------------
 -spec eval(Snapshot) -> Result
     when Snapshot :: snapshot()
-       , Result   :: binary()
+       , Result   :: iolist()
        .
 
 eval(#{static := Static, dynamic := Dynamic}) ->
@@ -41,12 +41,18 @@ eval(#{static := Static, dynamic := Dynamic}) ->
 %% -----------------------------------------------------------------------------
 -spec eval(Static, Dynamic) -> Result
     when Static  :: static()
-       , Dynamic :: [binary()]
-       , Result  :: binary()
+       , Dynamic :: dynamic()
+       , Result  :: iolist()
        .
 
 eval(Static, Dynamic) ->
-    unicode:characters_to_binary(retrieve_bin(zip(Static, Dynamic))).
+    retrieve_bin(zip(Static, Dynamic)).
+
+%% -----------------------------------------------------------------------------
+%% @doc retrieve_bin/1.
+%% @end
+%% -----------------------------------------------------------------------------
+-spec retrieve_bin([token()]) -> iolist().
 
 retrieve_bin(Tokens) ->
     lists:map(fun({_, {_, Bin}}) -> Bin end, Tokens).
@@ -55,7 +61,11 @@ retrieve_bin(Tokens) ->
 %% @doc zip/1.
 %% @end
 %% -----------------------------------------------------------------------------
--spec zip(tokens()) -> list().
+-spec zip({Static, Dynamic}) -> Result
+    when Static  :: static()
+       , Dynamic :: dynamic()
+       , Result  :: [token()]
+       .
 
 zip({Static, Dynamic}) ->
     zip(Static, Dynamic).
@@ -64,7 +74,7 @@ zip({Static, Dynamic}) ->
 %% @doc zip/2.
 %% @end
 %% -----------------------------------------------------------------------------
--spec zip(static(), dynamic()) -> list().
+-spec zip(static(), dynamic()) -> [token()].
 
 zip(Static, Dynamic) ->
     do_zip(Static, Dynamic, []).

--- a/src/eel_smart_engine.erl
+++ b/src/eel_smart_engine.erl
@@ -93,8 +93,8 @@ handle_body(#state{acc = Tokens}) ->
 
 %% compile callbacks
 
-handle_compile(Token, #state{opts = Opts} = State) ->
-    case eel_compiler:dynamic_to_ast(compile(Token, Opts)) of
+handle_compile(Tokens, #state{opts = Opts} = State) ->
+    case eel_compiler:dynamic_to_ast(compile(Tokens, Opts)) of
         {ok, AST} ->
             {ok, push(AST, State)};
         {error, Reason} ->
@@ -536,20 +536,12 @@ parse_tokens_to_sd_test() ->
     ?assertEqual(Expected, Result).
 
 handle_render_test() ->
-    Expected = <<
-        "<h1>EEl</h1>"
-        "<ul>"
-            "<li>foo</li>"
-            "<li>bar</li>"
-            "<li>baz</li>"
-        "</ul>"
-        "<div>Item count: 3</div>"
-        "<ul>"
-            "<li>1</li>"
-            "<li>2</li>"
-            "<li>3</li>"
-        "</ul>"
-    >>,
+    Expected =
+        [ <<"<h1>">>,<<"EEl">>,<<"</h1><ul>">>
+        , [<<"<li>foo</li>">>,<<"<li>bar</li>">>,<<"<li>baz</li>">>]
+        , <<"</ul>">>
+        , <<"<div>Item count: 3</div><ul><li>1</li><li>2</li><li>3</li></ul>">>
+        ],
     Bin = <<
         "<h1><%= maps:get('Title', Bindings, <<\"EEl\">>) .%></h1>"
         "<%% <h2><%= Foo .%></h2> %%>"


### PR DESCRIPTION
This PR changes the eval return to `iolist()`.
This performs better and the conversion to binary is stills possible.
See @josevalim [comment](https://erlangforums.com/t/eel-embedded-erlang-template-renderer-wip/1827/10?u=williamthome) in Erlang Forums about this change.