### PR TITLE
Improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A binary or a file can be evaluated to a binary, e.g.:
 
 ```erlang
 1> eel:eval(<<"Hello, <%= Name .%>!">>, #{'Name' => <<"World">>}).
-[<<"Hello, ">>,<<"World">>,<<"!">>]
+["Hello, ",<<"World">>,"!"]
 ```
 
 ### Module
@@ -21,7 +21,7 @@ A binary or a file can be compiled to a module, e.g.:
 1> eel:to_module(<<"Hello, <%= Name .%>!">>, foo).
 {ok,foo}
 2> foo:eval(#{'Name' => <<"World">>}).
-[<<"Hello, ">>,<<"World">>,<<"!">>]
+["Hello, ",<<"World">>,"!"]
 ```
 
 ## Example
@@ -60,65 +60,65 @@ rebar3 shell
 and type this in the Erlang shell
 
 ```erlang
-1> {_, Snapshot} = foo:render(#{title => <<"Hey!">>, who => <<"World">>}).
-{[<<"<html><head><title>">>,<<"Hey!">>,
-  <<"</title></head><body>Hello, ">>,<<"World">>,
-  <<"!</body></html>">>],
+1> {_, Snapshot} = foo:render(#{'Title' => <<"Hey!">>, 'Name' => <<"World">>}).
+{["<html><head><title>",<<"Hey!">>,
+  "</title></head><body>Hello, ",<<"World">>,
+  "!</body></html>"],
  #{ast =>
        [{2,
          {{1,20},
           [{call,1,
-               {remote,1,{atom,1,eel_converter},{atom,1,to_binary}},
+               {remote,1,{atom,1,eel_converter},{atom,1,to_string}},
                [{'fun',1,
                     {clauses,[{clause,1,[],[],[{var,1,'Title'}]}]}}]}]}},
         {4,
          {{1,61},
           [{call,1,
-               {remote,1,{atom,1,eel_converter},{atom,1,to_binary}},
+               {remote,1,{atom,1,eel_converter},{atom,1,to_string}},
                [{'fun',1,
                     {clauses,[{clause,1,[],[],[{var,1,...}]}]}}]}]}}],
-   bindings => #{'Title' => <<"Hey!">>,'Who' => <<"World">>},
+   bindings => #{'Name' => <<"World">>,'Title' => <<"Hey!">>},
    changes => [{2,<<"Hey!">>},{4,<<"World">>}],
    dynamic =>
        [{2,{{1,20},<<"Hey!">>}},{4,{{1,61},<<"World">>}}],
    static =>
-       [{1,{{1,1},<<"<html><head><title>">>}},
-        {3,{{1,33},<<"</title></head><body>Hello, ">>}},
-        {5,{{1,72},<<"!</body></html>">>}}],
-   vars => [{2,['Title']},{4,['Who']}]}}
-2> {Bin, _} = foo:render(#{who => <<"Erlang">>}, Snapshot).
-{[<<"<html><head><title>">>,<<"Hey!">>,
-  <<"</title></head><body>Hello, ">>,<<"Erlang">>,
-  <<"!</body></html>">>],
+       [{1,{{1,1},"<html><head><title>"}},
+        {3,{{1,33},"</title></head><body>Hello, "}},
+        {5,{{1,73},"!</body></html>"}}],
+   vars => [{2,['Title']},{4,['Name']}]}}
+2> {Bin, _} = foo:render(#{'Name' => <<"Erlang">>}, Snapshot).
+{["<html><head><title>",<<"Hey!">>,
+  "</title></head><body>Hello, ",<<"Erlang">>,
+  "!</body></html>"],
  #{ast =>
        [{2,
          {{1,20},
           [{call,1,
-               {remote,1,{atom,1,eel_converter},{atom,1,to_binary}},
+               {remote,1,{atom,1,eel_converter},{atom,1,to_string}},
                [{'fun',1,
                     {clauses,[{clause,1,[],[],[{var,1,'Title'}]}]}}]}]}},
         {4,
          {{1,61},
           [{call,1,
-               {remote,1,{atom,1,eel_converter},{atom,1,to_binary}},
+               {remote,1,{atom,1,eel_converter},{atom,1,to_string}},
                [{'fun',1,
                     {clauses,[{clause,1,[],[],[{var,1,...}]}]}}]}]}}],
-   bindings => #{'Title' => <<"Hey!">>,'Who' => <<"Erlang">>},
+   bindings => #{'Name' => <<"Erlang">>,'Title' => <<"Hey!">>},
    changes => [{4,<<"Erlang">>}],
    dynamic =>
        [{2,{{1,20},<<"Hey!">>}},{4,{{1,61},<<"Erlang">>}}],
    static =>
-       [{1,{{1,1},<<"<html><head><title>">>}},
-        {3,{{1,33},<<"</title></head><body>Hello, ">>}},
-        {5,{{1,72},<<"!</body></html>">>}}],
-   vars => [{2,['Title']},{4,['Who']}]}}
+       [{1,{{1,1},"<html><head><title>"}},
+        {3,{{1,33},"</title></head><body>Hello, "}},
+        {5,{{1,73},"!</body></html>"}}],
+   vars => [{2,['Title']},{4,['Name']}]}}
 ```
 
 Looking at the pattern matched results, the first tuple element contains the evaluated value
 ```erlang
-[<<"<html><head><title>">>,<<"Hey!">>,
- <<"</title></head><body>Hello, ">>,<<"World">>,
- <<"!</body></html>">>]
+["<html><head><title>",<<"Hey!">>,
+ "</title></head><body>Hello, ",<<"World">>,
+ "!</body></html>"],
 ```
 and the second a metadata called `snapshot` (see next)
 ```erlang
@@ -126,39 +126,38 @@ and the second a metadata called `snapshot` (see next)
        [{2,
          {{1,20},
           [{call,1,
-               {remote,1,{atom,1,eel_converter},{atom,1,to_binary}},
+               {remote,1,{atom,1,eel_converter},{atom,1,to_string}},
                [{'fun',1,
                     {clauses,[{clause,1,[],[],[{var,1,'Title'}]}]}}]}]}},
         {4,
          {{1,61},
           [{call,1,
-               {remote,1,{atom,1,eel_converter},{atom,1,to_binary}},
+               {remote,1,{atom,1,eel_converter},{atom,1,to_string}},
                [{'fun',1,
                     {clauses,[{clause,1,[],[],[{var,1,...}]}]}}]}]}}],
-   bindings => #{'Title' => <<"Hey!">>,'Who' => <<"World">>},
+   bindings => #{'Name' => <<"World">>,'Title' => <<"Hey!">>},
    changes => [{2,<<"Hey!">>},{4,<<"World">>}],
    dynamic =>
        [{2,{{1,20},<<"Hey!">>}},{4,{{1,61},<<"World">>}}],
    static =>
-       [{1,{{1,1},<<"<html><head><title>">>}},
-        {3,{{1,33},<<"</title></head><body>Hello, ">>}},
-        {5,{{1,72},<<"!</body></html>">>}}],
-   vars => [{2,['Title']},{4,['Who']}]}
+       [{1,{{1,1},"<html><head><title>"}},
+        {3,{{1,33},"</title></head><body>Hello, "}},
+        {5,{{1,73},"!</body></html>"}}],
+   vars => [{2,['Title']},{4,['Name']}]}
 ```
 
-The line `1` will evaluate the bindings `title` and `who`, but the line `2`
-will only eval the `who` variable, because it uses the snapshot of the previous
+The line `1` will evaluate the bindings `Title` and `Name`, but the line `2`
+will only eval the `Name` variable, because it uses the snapshot of the previous
 render. It only eval the changes and does not need to compile the binary again, unless the expression contains the global `Bindings` variable (see below),
 because the `snapshot` includes the required information.
 
 The global `Bindings` variable can be used to get values in a conditional way, checking if the variable exists in the template, e.g.:
 
 ```
-<%= maps:get(foo, Bindings, bar) .%>
+<%= maps:get('Foo', Bindings, bar) .%>
 ```
 
 Including `Bindings` to the expression makes it to be always evaluated by the render function.
-
 
 Including the header
 
@@ -184,7 +183,7 @@ The bindings are the unbound/required variables of the template. The syntax it's
 #{'Foo' => <<"foo">>, 'FooBar' => bar}
 ```
 
-or the same in lower case (note the snake case in foo_bar):
+or the same in lower case passing the option #{snake_case => true} to the compile function:
 
 ```erlang
 #{foo => <<"foo">>, foo_bar => bar}

--- a/src/eel.erl
+++ b/src/eel.erl
@@ -6,6 +6,12 @@
 %%%-----------------------------------------------------------------------------
 -module(eel).
 
+-compile({inline, [ compile/2
+                  , compile_file/2
+                  , render/3
+                  , render_file/3
+                  ]}).
+
 %% API functions
 -export([ compile/1
         , compile/2

--- a/src/eel_converter.erl
+++ b/src/eel_converter.erl
@@ -6,9 +6,11 @@
 %%%-----------------------------------------------------------------------------
 -module(eel_converter).
 
+-compile({inline, [ to_string/2 ]}).
+
 %% API functions
--export([ to_binary/1
-        , to_binary/2
+-export([ to_string/1
+        , to_string/2
         ]).
 
 %%%=============================================================================
@@ -16,50 +18,43 @@
 %%%=============================================================================
 
 %% -----------------------------------------------------------------------------
-%% @doc to_binary/1.
+%% @doc to_string/1.
 %% @end
 %% -----------------------------------------------------------------------------
--spec to_binary(term()) -> binary().
+-spec to_string(term()) -> iodata().
 
-to_binary(Value) ->
-    to_binary(Value, undefined).
+to_string(Value) ->
+    to_string(Value, undefined).
 
 %% -----------------------------------------------------------------------------
-%% @doc to_binary/2.
+%% @doc to_string/2.
 %% @end
 %% -----------------------------------------------------------------------------
--spec to_binary(term(), Options :: term()) -> binary().
+-spec to_string(term(), Options :: term()) -> iodata().
 
-to_binary(Bin, undefined) when is_binary(Bin) ->
+to_string(List, undefined) when is_list(List) ->
+    List;
+to_string(Bin, undefined) when is_binary(Bin) ->
     Bin;
-to_binary(Fun, undefined) when is_function(Fun, 0) ->
-    to_binary(Fun());
-to_binary(undefined, _) ->
+to_string(Fun, undefined) when is_function(Fun, 0) ->
+    to_string(Fun());
+to_string(undefined, _) ->
     <<>>;
-to_binary([], _) ->
+to_string([], _) ->
     <<>>;
-to_binary(Atom, undefined) when is_atom(Atom) ->
+to_string(Atom, undefined) when is_atom(Atom) ->
     erlang:atom_to_binary(Atom);
-to_binary(Atom, Encoding) when is_atom(Atom), is_atom(Encoding) ->
+to_string(Atom, Encoding) when is_atom(Atom), is_atom(Encoding) ->
     erlang:atom_to_binary(Atom, Encoding);
-to_binary(Float, undefined) when is_float(Float) ->
+to_string(Float, undefined) when is_float(Float) ->
     erlang:float_to_binary(Float);
-to_binary(Float, Options) when is_float(Float), is_list(Options) ->
+to_string(Float, Options) when is_float(Float), is_list(Options) ->
     erlang:float_to_binary(Float, Options);
-to_binary(Int, undefined) when is_integer(Int) ->
+to_string(Int, undefined) when is_integer(Int) ->
     erlang:integer_to_binary(Int);
-to_binary(Int, Base) when is_integer(Int), is_integer(Base) ->
+to_string(Int, Base) when is_integer(Int), is_integer(Base) ->
     erlang:integer_to_binary(Int, Base);
-to_binary(List, undefined) when is_list(List) ->
-    case io_lib:deep_unicode_char_list(List) of
-        true ->
-            erlang:list_to_binary(List);
-        false ->
-            lists:map(fun to_binary/1, List)
-    end;
-to_binary(Tuple, undefined) when is_tuple(Tuple) ->
-    to_binary(erlang:tuple_to_list(Tuple));
-to_binary(PID, undefined) when is_pid(PID) ->
-    erlang:list_to_binary(erlang:pid_to_list(PID));
-to_binary(Term, _) ->
-    erlang:list_to_binary(io_lib:format("~p", [Term])).
+to_string(PID, undefined) when is_pid(PID) ->
+    erlang:pid_to_list(PID);
+to_string(Term, _) ->
+    io_lib:format("~p", [Term]).

--- a/src/eel_engine.erl
+++ b/src/eel_engine.erl
@@ -20,8 +20,9 @@
 -type static()        :: [token()].
 -type dynamic()       :: [token()].
 -type ast()           :: erl_syntax:syntaxTree().
--type marker_id()     :: atom().
--type marker_symbol() :: nonempty_string().
+-type marker_id()     :: term().
+-type marker_symbol() :: binary().
+-type marker_size()   :: non_neg_integer().
 -type marker()        :: {marker_id(), { Start :: marker_symbol()
                                        , End   :: marker_symbol() }}.
 -type expressions()   :: {Outer :: expression(), Inner :: expression()}.
@@ -48,25 +49,25 @@
 %%% Callbacks
 %%%=============================================================================
 
--callback markers() -> [marker()].
-
 -callback init(options()) -> {ok, state()} | {error, term()}.
 
 %% tokenize
--callback handle_expr( index()
-                     , position()
-                     , marker_id()
-                     , expressions()
-                     , state() ) -> {ok, state()} | {error, term()}.
+-callback handle_expr_start( binary()
+                           , state() ) -> {ok, {StartMarker :: marker_symbol(), marker_size(), Rest :: binary(), state()}} | {error, term()}.
 
--callback handle_text( index()
-                     , position()
-                     , binary()
-                     , state() ) -> {ok, state()} | {error, term()}.
+-callback handle_expr_end( StartMarker :: marker_symbol()
+                         , binary()
+                         , state() ) -> {ok, state()} | {error, term()}.
 
--callback handle_body( state() ) -> {ok, {static(), dynamic()}} | {error, term()}.
+-callback handle_text( iodata()
+                     , position()
+                     , state() ) -> {ok, {iodata(), position(), state()}} | {error, term()}.
+
+-callback handle_body( [token()]
+                     , state() ) -> {ok, {static(), dynamic()}} | {error, term()}.
 
 %% compile
--callback handle_compile([token()], state()) -> {ok, state()} | {error, term()}.
+-callback handle_compile( [token()]
+                        , state()) -> {ok, state()} | {error, term()}.
 
--callback handle_ast( state() ) -> {ok, ast()} | {error, term()}.
+-callback handle_ast( ast(), state() ) -> {ok, ast()} | {error, term()}.

--- a/src/eel_evaluator.erl
+++ b/src/eel_evaluator.erl
@@ -6,6 +6,9 @@
 %%%-----------------------------------------------------------------------------
 -module(eel_evaluator).
 
+-compile(inline_list_funcs).
+-compile({inline, [ do_zip/3 ]}).
+
 %% API functions
 -export([ eval/1
         , eval/2

--- a/src/eel_renderer.erl
+++ b/src/eel_renderer.erl
@@ -6,6 +6,11 @@
 %%%-----------------------------------------------------------------------------
 -module(eel_renderer).
 
+-compile(inline_list_funcs).
+-compile({inline, [ render/3
+                  , capitalize_keys/2
+                  ]}).
+
 %% API functions
 -export([ render/1
         , render/2
@@ -38,7 +43,7 @@
 -type dynamic()  :: undefined | [binary()].
 -type ast()      :: eel_engine:ast().
 -type changes()  :: [{non_neg_integer(), binary()}].
-% TODO: Maybe change snapshot to a opaque record
+% TODO: Maybe change snapshot to an opaque record
 -type snapshot() :: #{ static   => static()
                      , dynamic  => dynamic()
                      , ast      => ast()
@@ -220,8 +225,10 @@ snapshot(Static, Dynamic, AST, Bindings, Vars, Changes) ->
 %% @end
 %% -----------------------------------------------------------------------------
 
-normalize_bindings(Bindings0, Opts) ->
-    capitalize_keys(Bindings0, Opts).
+normalize_bindings(Bindings, #{snake_case := true} = Opts) ->
+    capitalize_keys(Bindings, Opts);
+normalize_bindings(Bindings, #{}) ->
+    Bindings.
 
 eval(Exprs, Bindings) ->
     {value, Binary, _} = erl_eval:exprs(Exprs, Bindings),


### PR DESCRIPTION
This PR improves performance.

## Benchmarks

The measure was done using Benchee, an Elixir lib.

### Mix (mix.exs)

```elixir
defmodule EelBench.MixProject do
  # ...

  # Run "mix help deps" to learn about dependencies.
  defp deps do
    [
      {:benchee, "~> 1.1", only: :dev},
      {:eel, git: "https://github.com/williamthome/eel.git", branch: "feat/improve-performance"}
    ]
  end
end
```

### Script (benchmark.exs)

```elixir
list = Enum.to_list 1..10

Benchee.run(%{
  "eex" => fn ->
    EEx.eval_string "Foo<%= Enum.map(list, fn(x) -> %><p><%= x %></p><% end) %>Bar", [list: list]
  end,
  "eel" => fn ->
    :eel.eval("Foo<%= lists:map(fun(X) -> %><p><%= X .%></p><% end, List) .%>Bar", %{List: list})
  end
})
```

### Run

Get the deps

```
mix deps.get
```

and run the benchmark

```
mix run benchmark.exs
```

### Results

#### Machine config

```
Operating System: Linux
CPU Information: Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
Number of Available Cores: 8
Available memory: 15.55 GB
Elixir 1.14.2
Erlang 25.3.2

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 0 ns
reduction time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 14 s
```

#### Run 1

```
Name           ips        average  deviation         median         99th %
eel        10.13 K       98.67 μs    ±20.17%       94.70 μs      195.18 μs
eex         9.33 K      107.14 μs    ±16.44%      103.34 μs      193.03 μs

Comparison: 
eel        10.13 K
eex         9.33 K - 1.09x slower +8.47 μs
```

#### Run 2

```
Name           ips        average  deviation         median         99th %
eel         9.88 K      101.22 μs    ±19.09%       96.63 μs      194.44 μs
eex         9.34 K      107.03 μs    ±16.08%      102.91 μs      188.58 μs

Comparison: 
eel         9.88 K
eex         9.34 K - 1.06x slower +5.80 μs
```

#### Run 3

```
Name           ips        average  deviation         median         99th %
eel        10.00 K      100.01 μs    ±19.81%       96.08 μs      194.63 μs
eex         9.33 K      107.20 μs    ±16.84%      102.62 μs      191.34 μs

Comparison: 
eel        10.00 K
eex         9.33 K - 1.07x slower +7.19 μs
```