### PR TITLE
Refactor code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Compile
       run: rebar3 compile
-    # TODO:
-    # - name: Format check
-    #   run: rebar3 fmt --check
     - name: Run dialyzer
       run: rebar3 dialyzer
     - name: Run tests

--- a/src/eel.erl
+++ b/src/eel.erl
@@ -102,7 +102,7 @@ file_to_module(Filename) ->
 file_to_module(Filename, Module) when is_atom(Module) ->
     file_to_module(Filename, Module, default_engine_opts());
 file_to_module(Filename, Opts) when is_map(Opts) ->
-    Module = eel_compiler:file_module(Filename),
+    Module = eel_converter:filename_to_module(Filename),
     file_to_module(Filename, Module, Opts).
 
 file_to_module(Filename, Module, Opts) ->

--- a/src/eel.erl
+++ b/src/eel.erl
@@ -61,7 +61,7 @@ compile(Bin, Opts) ->
         {ok, {Static, Dynamic}} ->
             case eel_compiler:compile(Dynamic, Opts) of
                 {ok, AST} ->
-                    {ok, eel_renderer:snapshot(Static, AST)};
+                    {ok, eel_snapshot:new(Static, AST)};
                 {error, Reason} ->
                     {error, Reason}
             end;
@@ -77,7 +77,7 @@ compile_file(Filename, Opts) ->
         {ok, {Static, Dynamic}} ->
             case eel_compiler:compile(Dynamic, Opts) of
                 {ok, AST} ->
-                    {ok, eel_renderer:snapshot(Static, AST)};
+                    {ok, eel_snapshot:new(Static, AST)};
                 {error, Reason} ->
                     {error, Reason}
             end;
@@ -124,7 +124,7 @@ render(Bin, Bindings, Opts) ->
         {ok, {Static, Dynamic}} ->
             case eel_compiler:compile(Dynamic, Opts) of
                 {ok, AST} ->
-                    Snapshot = eel_renderer:snapshot(Static, Dynamic, AST),
+                    Snapshot = eel_snapshot:new(Static, Dynamic, AST),
                     eel_renderer:render(Bindings, Snapshot, Opts);
                 {error, Reason} ->
                     {error, Reason}
@@ -144,7 +144,7 @@ render_file(Filename, Bindings, Opts) ->
         {ok, {Static, Dynamic}} ->
             case eel_compiler:compile(Dynamic, Opts) of
                 {ok, AST} ->
-                    Snapshot = eel_renderer:snapshot(Static, Dynamic, AST),
+                    Snapshot = eel_snapshot:new(Static, Dynamic, AST),
                     eel_renderer:render(Bindings, Snapshot, Opts);
                 {error, Reason} ->
                     {error, Reason}

--- a/src/eel_compiler.erl
+++ b/src/eel_compiler.erl
@@ -37,7 +37,7 @@
 -type dynamic()  :: eel_engine:dynamic().
 -type ast()      :: eel_engine:ast().
 -type index()    :: eel_engine:index().
--type snapshot() :: eel_renderer:snapshot().
+-type snapshot() :: eel_snapshot:snapshot().
 -type position() :: eel_engine:position().
 
 %%%=============================================================================

--- a/src/eel_compiler.erl
+++ b/src/eel_compiler.erl
@@ -20,7 +20,6 @@
         , compile_file_to_module/3
         , dynamic_to_ast/1
         , ast_vars/1
-        , file_module/1
         ]).
 
 %% Types
@@ -184,26 +183,6 @@ ast_vars(AST) when is_list(AST) ->
     );
 ast_vars(AST) when is_tuple(AST) ->
     ast_vars([AST]).
-
-%% -----------------------------------------------------------------------------
-%% @doc ast_vars/1.
-%% @end
-%% -----------------------------------------------------------------------------
--spec file_module(Filename) -> Result
-    when Filename :: file:filename_all()
-       , Result   :: module()
-       .
-
-% TODO: Rename fun to file_module_name
-% TODO: safe option, and when true use erlang:binary_to_existing_atom/1
-file_module(Filename) when is_binary(Filename); is_list(Filename) ->
-    Basename =
-        case filename:basename(Filename) of
-            N when is_binary(N) -> N;
-            N when is_list(N) -> list_to_binary(N)
-        end,
-    Name = binary:replace(Basename, <<".">>, <<"_">>, [global]),
-    erlang:binary_to_atom(Name).
 
 %%%=============================================================================
 %%% Internal functions

--- a/src/eel_converter.erl
+++ b/src/eel_converter.erl
@@ -11,6 +11,7 @@
 %% API functions
 -export([ to_string/1
         , to_string/2
+        , filename_to_module/1
         ]).
 
 %%%=============================================================================
@@ -58,3 +59,18 @@ to_string(PID, undefined) when is_pid(PID) ->
     erlang:pid_to_list(PID);
 to_string(Term, _) ->
     io_lib:format("~p", [Term]).
+
+%% -----------------------------------------------------------------------------
+%% @doc filename_to_module/1.
+%% @end
+%% -----------------------------------------------------------------------------
+-spec filename_to_module(file:filename_all()) -> module().
+
+filename_to_module(Filename) when is_binary(Filename); is_list(Filename) ->
+    Basename =
+        case filename:basename(Filename) of
+            N when is_binary(N) -> N;
+            N when is_list(N) -> list_to_binary(N)
+        end,
+    Name = binary:replace(Basename, <<".">>, <<"_">>, [global]),
+    erlang:binary_to_atom(Name).

--- a/src/eel_engine.erl
+++ b/src/eel_engine.erl
@@ -23,8 +23,9 @@
 -type marker_id()     :: term().
 -type marker_symbol() :: binary().
 -type marker_size()   :: non_neg_integer().
--type marker()        :: {marker_id(), { Start :: marker_symbol()
-                                       , End   :: marker_symbol() }}.
+-type marker()        :: {marker_id(), { StartMarker :: marker_symbol()
+                                       , EndMarker   :: marker_symbol() }}
+                                       .
 -type expressions()   :: {Outer :: expression(), Inner :: expression()}.
 -type options()       :: map().
 
@@ -49,25 +50,59 @@
 %%% Callbacks
 %%%=============================================================================
 
--callback init(options()) -> {ok, state()} | {error, term()}.
+-callback init(Opts) -> Result
+    when Opts   :: options()
+       , Result :: {ok, state()} | {error, term()}
+       .
 
 %% tokenize
--callback handle_expr_start( binary()
-                           , state() ) -> {ok, {StartMarker :: marker_symbol(), marker_size(), Rest :: binary(), state()}} | {error, term()}.
+-callback handle_expr_start(Bin, State) -> Result
+    when Bin             :: binary()
+       , State           :: state()
+       , Result          :: {ok, Data} | {error, term()}
+       , Data            :: {StartMarker, StartMarkerSize, Rest, NewState}
+       , StartMarker     :: marker_symbol()
+       , StartMarkerSize :: marker_size()
+       , Rest            :: binary()
+       , NewState        :: state()
+       .
 
--callback handle_expr_end( StartMarker :: marker_symbol()
-                         , binary()
-                         , state() ) -> {ok, state()} | {error, term()}.
+-callback handle_expr_end(StartMarker, Bin, State) -> Result
+    when StartMarker :: marker_symbol()
+       , Bin         :: binary()
+       , State       :: state()
+       , Result      :: {ok, NewState} | {error, term()}
+       , NewState    :: state()
+       .
 
--callback handle_text( iodata()
-                     , position()
-                     , state() ) -> {ok, {iodata(), position(), state()}} | {error, term()}.
+-callback handle_text(Text, Pos, State) -> Result
+    when Text     :: nonempty_string()
+       , Pos      :: position()
+       , State    :: state()
+       , Result   :: {ok, Data} | {error, term()}
+       , Data     :: {NewText, NewPos, NewState}
+       , NewText  :: nonempty_string()
+       , NewPos   :: position()
+       , NewState :: state()
+       .
 
--callback handle_body( [token()]
-                     , state() ) -> {ok, {static(), dynamic()}} | {error, term()}.
+-callback handle_body(Tokens, State) -> Result
+    when Tokens :: [token()]
+       , State  :: state()
+       , Result :: {ok, {static(), dynamic()}} | {error, term()}
+       .
 
 %% compile
--callback handle_compile( [token()]
-                        , state()) -> {ok, state()} | {error, term()}.
+-callback handle_compile(Tokens, State) -> Result
+    when Tokens   :: [token()]
+       , State    :: state()
+       , Result   :: {ok, NewState} | {error, term()}
+       , NewState :: state()
+       .
 
--callback handle_ast( ast(), state() ) -> {ok, ast()} | {error, term()}.
+-callback handle_ast(AST, State) -> Result
+    when AST    :: ast()
+       , State  :: state()
+       , Result :: {ok, NewAST} | {error, term()}
+       , NewAST :: ast()
+       .

--- a/src/eel_evaluator.erl
+++ b/src/eel_evaluator.erl
@@ -17,10 +17,10 @@
         ]).
 
 % Types
--type snapshot() :: eel_renderer:snapshot().
--type token()    :: eel_tokenizer:token().
--type static()   :: eel_engine:static().
+-type snapshot() :: eel_snapshot:snapshot().
+-type static()   :: eel_snapshot:static().
 -type dynamic()  :: eel_engine:dynamic().
+-type token()    :: eel_tokenizer:token().
 
 %%%=============================================================================
 %%% API functions
@@ -35,7 +35,9 @@
        , Result   :: iolist()
        .
 
-eval(#{static := Static, dynamic := Dynamic}) ->
+eval(Snapshot) ->
+    Static = eel_snapshot:get_static(Snapshot),
+    Dynamic = eel_snapshot:get_dynamic(Snapshot),
     eval(Static, Dynamic).
 
 %% -----------------------------------------------------------------------------

--- a/src/eel_renderer.erl
+++ b/src/eel_renderer.erl
@@ -15,10 +15,6 @@
 -export([ render/1
         , render/2
         , render/3
-        , snapshot/2
-        , snapshot/3
-        , snapshot/4
-        , snapshot/6
         ]).
 
 %% Types
@@ -37,20 +33,11 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
-%% Type
--type bindings() :: map().
--type static()   :: eel_engine:static().
--type dynamic()  :: undefined | [binary()].
--type ast()      :: eel_engine:ast().
--type changes()  :: [{non_neg_integer(), binary()}].
-% TODO: Maybe change snapshot to an opaque record
--type snapshot() :: #{ static   => static()
-                     , dynamic  => dynamic()
-                     , ast      => ast()
-                     , bindings => bindings()
-                     , vars     => [atom()]
-                     , changes  => changes()
-                     }.
+%% Types
+-type snapshot() :: eel_snapshot:snapshot().
+-type bindings() :: eel_snapshot:bindings().
+-type dynamic()  :: eel_snapshot:dynamice().
+-type changes()  :: eel_snapshot:changes().
 -type options()  :: map().
 -type result()   :: {ok, snapshot()}.
 
@@ -94,14 +81,12 @@ render(Bindings, Snapshot) ->
        , Result   :: result()
        .
 
-render( Params0
-      , #{ static   := Static
-         , dynamic  := DynamicSnap
-         , ast      := AST
-         , bindings := BindingsSnap
-         , vars     := Vars
-         }
-      , Opts ) ->
+render(Params0, Snapshot, Opts) ->
+    Static = eel_snapshot:get_static(Snapshot),
+    DynamicSnap = eel_snapshot:get_dynamic(Snapshot),
+    AST = eel_snapshot:get_ast(Snapshot),
+    BindingsSnap = eel_snapshot:get_bindings(Snapshot),
+    Vars = eel_snapshot:get_vars(Snapshot),
     Params = normalize_bindings(Params0, Opts),
     Bindings = maps:merge(BindingsSnap, Params),
     EvalBindings = Bindings#{'Bindings' => Bindings},
@@ -138,7 +123,7 @@ render( Params0
         ),
     Dynamic = lists:reverse(Dynamic0),
     Changes = lists:reverse(Changes0),
-    {ok, snapshot(Static, Dynamic, AST, Bindings, Vars, Changes)}.
+    {ok, eel_snapshot:new(Static, Dynamic, AST, Bindings, Vars, Changes)}.
 
 should_eval_exprs(undefined, _, _) ->
     true;
@@ -152,72 +137,6 @@ eval(Exprs, Bindings) ->
 contains_any_var(Map, Vars) ->
     MapKeys = maps:keys(Map),
     lists:any(fun(V) -> lists:member(V, MapKeys) end, Vars).
-
-%% -----------------------------------------------------------------------------
-%% @doc snapshot/2.
-%% @end
-%% -----------------------------------------------------------------------------
--spec snapshot(Static, AST) -> Result
-    when Static :: static()
-       , AST    :: ast()
-       , Result :: snapshot()
-       .
-
-snapshot(Static, AST) ->
-    snapshot(Static, undefined, AST).
-
-%% -----------------------------------------------------------------------------
-%% @doc snapshot/3.
-%% @end
-%% -----------------------------------------------------------------------------
--spec snapshot(Static, Dynamic, AST) -> Result
-    when Static  :: static()
-       , Dynamic :: dynamic()
-       , AST     :: ast()
-       , Result  :: snapshot()
-       .
-
-snapshot(Static, Dynamic, AST) ->
-    snapshot(Static, Dynamic, AST, #{}).
-
-%% -----------------------------------------------------------------------------
-%% @doc snapshot/4.
-%% @end
-%% -----------------------------------------------------------------------------
--spec snapshot(Static, Dynamic, AST, Bindings) -> Result
-    when Static   :: static()
-       , Dynamic  :: dynamic()
-       , AST      :: ast()
-       , Bindings :: bindings()
-       , Result   :: snapshot()
-       .
-
-snapshot(Static, Dynamic, AST, Bindings) ->
-    Vars = eel_compiler:ast_vars(AST),
-    snapshot(Static, Dynamic, AST, Bindings, Vars, []).
-
-%% -----------------------------------------------------------------------------
-%% @doc snapshot/5.
-%% @end
-%% -----------------------------------------------------------------------------
--spec snapshot(Static, Dynamic, AST, Bindings, Vars, Changes) -> Result
-    when Static   :: static()
-       , Dynamic  :: dynamic()
-       , AST      :: ast()
-       , Bindings :: bindings()
-       , Vars     :: [atom()]
-       , Changes  :: changes()
-       , Result   :: snapshot()
-       .
-
-snapshot(Static, Dynamic, AST, Bindings, Vars, Changes) ->
-    #{ static   => Static
-     , dynamic  => Dynamic
-     , ast      => AST
-     , bindings => Bindings
-     , vars     => Vars
-     , changes  => Changes
-     }.
 
 %%%=============================================================================
 %%% Internal functions

--- a/src/eel_renderer.erl
+++ b/src/eel_renderer.erl
@@ -119,8 +119,12 @@ render( Params0
                                 ?LOG_ERROR(#{ class => Class
                                             , reason => Reason
                                             , stacktrace => Stacktrace
+                                            , module => ?MODULE
+                                            , function => ?FUNCTION_NAME
+                                            , arity => ?FUNCTION_ARITY
                                             , ast => EvalAST
                                             , position => Pos
+                                            , bindings => Bindings
                                             }),
                                 erlang:raise(Class, Reason, Stacktrace)
                         end;
@@ -140,6 +144,10 @@ should_eval_exprs(undefined, _, _) ->
     true;
 should_eval_exprs(_, Params, Vars) ->
     lists:member('Bindings', Vars) orelse contains_any_var(Params, Vars).
+
+eval(Exprs, Bindings) ->
+    {value, Binary, _} = erl_eval:exprs(Exprs, Bindings),
+    Binary.
 
 contains_any_var(Map, Vars) ->
     MapKeys = maps:keys(Map),
@@ -229,10 +237,6 @@ normalize_bindings(Bindings, #{snake_case := true} = Opts) ->
     capitalize_keys(Bindings, Opts);
 normalize_bindings(Bindings, #{}) ->
     Bindings.
-
-eval(Exprs, Bindings) ->
-    {value, Binary, _} = erl_eval:exprs(Exprs, Bindings),
-    Binary.
 
 capitalize_keys(Bindings, Opts) when is_list(Bindings) ->
     lists:map(fun({K, V}) -> {capitalize(K, Opts), V} end, Bindings);

--- a/src/eel_smart_engine.erl
+++ b/src/eel_smart_engine.erl
@@ -169,8 +169,14 @@ do_parse_tokens_to_sd_1( [{Index, {text, Pos, Text}} | T]
                        , in_text
                        , {PrevIndex, {text, PrevPos, PrevText}}
                        , {[{PrevIndex, {PrevPos, PrevText}} | S], D} ) ->
-    Concat = [PrevText, Text],
-    do_parse_tokens_to_sd_2(T, {Index, {text, Pos, Concat}}, in_text, {Index, {text, Pos, Concat}}, {[{Index, {Pos, Concat}} | S], D});
+    MergedText  = [PrevText, Text],
+    MergedToken = {Index, {text, Pos, MergedText}},
+    do_parse_tokens_to_sd_2( T
+                           , MergedToken
+                           , in_text
+                           , MergedToken
+                           , {[{Index, {Pos, MergedText}} | S], D}
+                           );
 do_parse_tokens_to_sd_1( [{Index, {text, Pos, Text}} = H | T]
                        , in_text
                        , Prev

--- a/src/eel_snapshot.erl
+++ b/src/eel_snapshot.erl
@@ -1,0 +1,127 @@
+-module(eel_snapshot).
+
+-export([ new/2
+        , new/3
+        , new/4
+        , new/6
+        , get_static/1
+        , get_dynamic/1
+        , get_ast/1
+        , get_bindings/1
+        , get_vars/1
+        , get_changes/1
+        ]).
+
+-export_type([ snapshot/0
+             , bindings/0
+             , static/0
+             , dynamic/0
+             , ast/0
+             , vars/0
+             , changes/0
+             ]).
+
+-record(snapshot, { static   :: static()
+                  , dynamic  :: dynamic()
+                  , ast      :: ast()
+                  , bindings :: bindings()
+                  , vars     :: vars()
+                  , changes  :: changes()
+                  }).
+
+%% Types
+-type snapshot() :: #snapshot{}.
+-type bindings() :: map().
+-type static()   :: eel_engine:static().
+-type dynamic()  :: undefined | [binary()].
+-type ast()      :: eel_engine:ast().
+-type vars()     :: [atom()].
+-type changes()  :: [{non_neg_integer(), binary()}].
+
+%%%=============================================================================
+%%% API functions
+%%%=============================================================================
+
+%% -----------------------------------------------------------------------------
+%% @doc new/2.
+%% @end
+%% -----------------------------------------------------------------------------
+-spec new(Static, AST) -> Result
+    when Static :: static()
+       , AST    :: ast()
+       , Result :: snapshot()
+       .
+
+new(Static, AST) ->
+    new(Static, undefined, AST).
+
+%% -----------------------------------------------------------------------------
+%% @doc new/3.
+%% @end
+%% -----------------------------------------------------------------------------
+-spec new(Static, Dynamic, AST) -> Result
+    when Static  :: static()
+       , Dynamic :: dynamic()
+       , AST     :: ast()
+       , Result  :: snapshot()
+       .
+
+new(Static, Dynamic, AST) ->
+    new(Static, Dynamic, AST, #{}).
+
+%% -----------------------------------------------------------------------------
+%% @doc new/4.
+%% @end
+%% -----------------------------------------------------------------------------
+-spec new(Static, Dynamic, AST, Bindings) -> Result
+    when Static   :: static()
+       , Dynamic  :: dynamic()
+       , AST      :: ast()
+       , Bindings :: bindings()
+       , Result   :: snapshot()
+       .
+
+new(Static, Dynamic, AST, Bindings) ->
+    Vars = eel_compiler:ast_vars(AST),
+    new(Static, Dynamic, AST, Bindings, Vars, []).
+
+%% -----------------------------------------------------------------------------
+%% @doc new/5.
+%% @end
+%% -----------------------------------------------------------------------------
+-spec new(Static, Dynamic, AST, Bindings, Vars, Changes) -> Result
+    when Static   :: static()
+       , Dynamic  :: dynamic()
+       , AST      :: ast()
+       , Bindings :: bindings()
+       , Vars     :: [atom()]
+       , Changes  :: changes()
+       , Result   :: snapshot()
+       .
+
+new(Static, Dynamic, AST, Bindings, Vars, Changes) ->
+    #snapshot{ static   = Static
+             , dynamic  = Dynamic
+             , ast      = AST
+             , bindings = Bindings
+             , vars     = Vars
+             , changes  = Changes
+             }.
+
+get_static(#snapshot{static = Static}) ->
+    Static.
+
+get_dynamic(#snapshot{dynamic = Dynamic}) ->
+    Dynamic.
+
+get_ast(#snapshot{ast = AST}) ->
+    AST.
+
+get_bindings(#snapshot{bindings = Bindings}) ->
+    Bindings.
+
+get_vars(#snapshot{vars = Vars}) ->
+    Vars.
+
+get_changes(#snapshot{changes = Changes}) ->
+    Changes.

--- a/src/eel_tokenizer.erl
+++ b/src/eel_tokenizer.erl
@@ -40,7 +40,7 @@
 
 %% Types
 -type tokens() :: {eel_engine:static(), eel_engine:dynamic()}.
--type result() :: {ok, tokens()} | {error, no_end_marker}.
+-type result() :: {ok, tokens()} | {error, term()}.
 
 %%%=============================================================================
 %%% API functions

--- a/src/eel_tokenizer.erl
+++ b/src/eel_tokenizer.erl
@@ -50,32 +50,32 @@
 %% @doc tokenize/1.
 %% @end
 %% -----------------------------------------------------------------------------
--spec tokenize(binary()) -> result().
+-spec tokenize(iodata()) -> result().
 
-tokenize(Bin) ->
-    tokenize(Bin, ?DEFAULT_ENGINE_OPTS).
+tokenize(IoData) ->
+    tokenize(IoData, ?DEFAULT_ENGINE_OPTS).
 
 %% -----------------------------------------------------------------------------
 %% @doc tokenize/2.
 %% @end
 %% -----------------------------------------------------------------------------
--spec tokenize(binary(), map()) -> result().
+-spec tokenize(iodata(), map()) -> result().
 
-% TODO: Maybe reduce verification to improve speed (let it crash!).
-
-tokenize(Bin, Opts) ->
+tokenize(Bin, Opts) when is_binary(Bin) ->
     Eng = maps:get(engine, Opts, ?DEFAULT_ENGINE),
     case Eng:init(Opts) of
-        {ok, State} ->
-            case do_tokenize(Bin, Eng, State, 1, {1, 1}, {1, 1}, [], []) of
-                {ok, {Tokens, NewState}} ->
-                    Eng:handle_body(Tokens, NewState);
+        {ok, InitState} ->
+            case do_tokenize(Bin, Eng, InitState, 1, {1, 1}, {1, 1}, [], []) of
+                {ok, {Tokens, EndState}} ->
+                    Eng:handle_body(Tokens, EndState);
                 {error, Reason} ->
                     {error, Reason}
             end;
         {error, Reason} ->
             {error, Reason}
-    end.
+    end;
+tokenize(List, Opts) when is_list(List) ->
+    tokenize(erlang:iolist_to_binary(List), Opts).
 
 %% -----------------------------------------------------------------------------
 %% @doc tokenize_file/1.

--- a/src/eel_transform.erl
+++ b/src/eel_transform.erl
@@ -11,12 +11,6 @@
 parse_transform(Forms, _Options) ->
     deepmap(fun transform/1, Forms).
 
-transform({call, _, {remote, _, {atom, _, eel}, {atom, _, compile}}, _} = Form0) ->
-    {value, Form, []} = erl_eval:expr(Form0, []),
-    erl_syntax:revert(erl_syntax:abstract(Form));
-transform(Form) ->
-    Form.
-
 deepmap(Fun, Forms) when is_function(Fun, 1), is_list(Forms) ->
     do_deepmap(Forms, Fun).
 
@@ -36,3 +30,14 @@ do_deepmap(Forms, F) when is_list(Forms) ->
     lists:map(fun(Form) -> do_deepmap(Form, F) end, Forms);
 do_deepmap(Form, F) ->
     F(Form).
+
+transform({call, _, {remote, _, {atom, _, eel}, {atom, _, compile}}, _} = Form0) ->
+    eval(Form0);
+transform({call, _, {remote, _, {atom, _, eel}, {atom, _, compile_file}}, _} = Form0) ->
+    eval(Form0);
+transform(Form) ->
+    Form.
+
+eval(Form0) ->
+    {value, Form, []} = erl_eval:expr(Form0, []),
+    erl_syntax:revert(erl_syntax:abstract(Form)).


### PR DESCRIPTION
This PR does some refactors and features:

- A specific module to snapshot was implemented. Now `snapshot` is a record, and to create or get a snapshot value the `eel_snapshot` module should be used;
- Format parts of the code;
- Log tokenizer errors;
- Accept `iodata()` instead of just `binary()` in the tokenizer function;
- Now `eel:compile_file` functions are also evaluated when using the `eel` header;
- Updates docs.